### PR TITLE
Fix header validation variable names in notebooks

### DIFF
--- a/patient_details_script.ipynb
+++ b/patient_details_script.ipynb
@@ -37,7 +37,7 @@
     "        return: delimiter_check, header_content_check, no_of_columns_check\n",
     "        \"\"\"\n",
     "        delimiter_check = len(patient_df.columns) > 1\n",
-    "        header_content_check = list_of_headers == list(patient_df)\n",
+    "        header_content_check = list_of_header == list(patient_df)\n",
     "        no_of_columns_check = len(patient_df.columns) == no_of_columns\n",
     "        return delimiter_check, header_content_check, no_of_columns_check\n",
     "    \n",

--- a/patient_discharge_details_script.ipynb
+++ b/patient_discharge_details_script.ipynb
@@ -42,7 +42,7 @@
     "        return: delimiter_check, header_content_check, no_of_columns_check\n",
     "        \"\"\"\n",
     "        delimiter_check = len(patient_discharge_df.columns) > 1\n",
-    "        header_content_check = list_of_headers == list(patient_discharge_df)\n",
+    "        header_content_check = list_of_header == list(patient_discharge_df)\n",
     "        no_of_columns_check = len(patient_discharge_df.columns) == no_of_columns\n",
     "        return delimiter_check, header_content_check, no_of_columns_check\n",
     "    \n",


### PR DESCRIPTION
## Summary
- fix header validation variable names in `patient_details_script.ipynb`
- fix header validation variable names in `patient_discharge_details_script.ipynb`

## Testing
- `python - <<'PY'
import json, sys
for fname in ['patient_details_script.ipynb', 'patient_discharge_details_script.ipynb']:
    with open(fname) as f:
        nb=json.load(f)
    for cell in nb['cells']:
        if cell['cell_type']=='code':
            src=''.join(cell['source'])
            try:
                compile(src, '<string>', 'exec')
            except SyntaxError as e:
                print(fname, 'syntax error in cell:', e)
                sys.exit(1)
print('ok')
PY`

------
https://chatgpt.com/codex/tasks/task_e_68413b0fdf7c832a9403514c17c88a7d