### PR TITLE
Fix department dashboard export docs

### DIFF
--- a/department_wise_dashboard.ipynb
+++ b/department_wise_dashboard.ipynb
@@ -63,7 +63,7 @@
     "    \n",
     "    def to_csv(self, group_by_department_df, path):\n",
     "        \"\"\"\n",
-    "        this method  will write department_wise.csv file in dashboard_files/department directory\n",
+    "        This method will write department_wise.csv file in dashboards/department directory\n",
     "        return: True\n",
     "        \"\"\"\n",
     "        group_by_department_df.to_csv(path, encoding='utf-8', index=False)\n",
@@ -75,7 +75,7 @@
     "    patient_discharge_df = department_wise_obj.read_csv('clean_files/clean_patient_discharge_details_dump.csv')\n",
     "    patient_discharge_df = department_wise_obj.add_total_expense_column(patient_discharge_df)\n",
     "    group_by_department_df = department_wise_obj.group_by_department_wise_script(patient_discharge_df)\n",
-    "    department_wise_obj.to_csv(group_by_department_df, 'dashboard_files/department/department_wise.csv')\n"
+    "    department_wise_obj.to_csv(group_by_department_df, 'dashboards/department/department_wise.csv')\n"
    ]
   },
   {


### PR DESCRIPTION
## Summary
- correct the DepartmentDashboard.to_csv docstring path
- update usage example to use `dashboards/department/department_wise.csv`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68413c0b17b0832a92617ed7686d1164